### PR TITLE
Added marker and value tags to base model

### DIFF
--- a/Ontology/crossdomain/basemodel.json
+++ b/Ontology/crossdomain/basemodel.json
@@ -66,6 +66,44 @@
             "@type": "Component",
             "name": "location",
             "schema": "dtmi:digitaltwins:ngsi_ld:city:geoLocation;1"
+        },
+        {
+            "@type": "Property",
+            "name": "markers",
+            "displayName": "Marker tags",
+            "description": "A marker tag is a simple string that is used to mark or categorize a digital twin, such as \"blue\" or \"red\". This string is the tag's name, and marker tags have no meaningful value—the tag is significant just by its presence (or absence).",
+            "comment": "Based on Haystack tag model https://project-haystack.org/doc/TagModel. See also https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-tags",
+            "schema": {
+                "@type": "Map",
+                "mapKey": {
+                    "name": "tagName",
+                    "schema": "string"
+                },
+                "mapValue": {
+                    "name": "tagValue",
+                    "schema": "boolean"
+                }
+            },
+            "writable": true
+        },
+        {
+            "@type": "Property",
+            "name": "tags",
+            "displayName": "Value tags",
+            "description": "A value tag is a key-value pair that is used to give each tag a value, such as \"color\": \"blue\" or \"color\": \"red\". Once a value tag is created, it can also be used as a marker tag by ignoring the tag's value.",
+            "comment": "Based on Haystack tag model https://project-haystack.org/doc/TagModel. See also https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-tags",
+            "schema": {
+                "@type": "Map",
+                "mapKey": {
+                    "name": "tagName",
+                    "schema": "string"
+                },
+                "mapValue": {
+                    "name": "tagValue",
+                    "schema": "string"
+                }
+            },
+            "writable": true
         }
     ],
     "@context": [


### PR DESCRIPTION
Many IoT solutions and 3rd Party visualization tools like the one from Bentley Systems need a simple way to store basic metadata information on a twin by leveraging a tags model. Therefore marker and value tags properties were added to the base model. This approach is according to the Haystack tag model and is explained on the [ADT website](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-tags).