### PR TITLE
ParkingSpot entity - Status attribute from Telemetry to Property

### DIFF
--- a/Ontology/Parking/ParkingSpot/ParkingSpot.json
+++ b/Ontology/Parking/ParkingSpot/ParkingSpot.json
@@ -63,7 +63,7 @@
             "writable": true
         },
         {
-            "@type": "Telemetry",
+            "@type": "Property",
             "name": "status",
             "schema": {
                 "@type": "Enum",


### PR DESCRIPTION
To have its last state saved in the graph, the attribute 'status' was changed from type 'Telemetry' to 'Property'. With this change ADT queries on the status of a ParkingSpot will be possible.